### PR TITLE
beagle-pwm-export set exit status when run without sudo

### DIFF
--- a/generic-sys-mods/suite/noble/debian/beagle-pwm-export
+++ b/generic-sys-mods/suite/noble/debian/beagle-pwm-export
@@ -3,7 +3,7 @@
 if ! id | grep -q root; then
 	echo "beagle-pwm-export must be run as root:"
 	echo "sudo beagle-pwm-export"
-	exit
+	exit 1
 fi
 
 unset GOTPIN


### PR DESCRIPTION
By returning an exit code of 1, calling scripts and programs can detect that the script failed to export the PWM pin as expected.